### PR TITLE
Feature/gallery crash fix

### DIFF
--- a/app/src/main/java/pl/temomuko/autostoprace/data/local/photo/PhotoShadowActivity.java
+++ b/app/src/main/java/pl/temomuko/autostoprace/data/local/photo/PhotoShadowActivity.java
@@ -53,6 +53,8 @@ public class PhotoShadowActivity extends BaseActivity {
 
     private static final int NOT_SET = -1;
 
+    private static final String GALLERY_INTENT_TYPE = "image/*";
+
     private File cameraPhotoFile;
     private Uri cameraPhotoUri;
     private int maxWidthHeightInPx;
@@ -229,7 +231,7 @@ public class PhotoShadowActivity extends BaseActivity {
 
     private void requestPhotoFromGallery() {
         Intent intent = new Intent();
-        intent.setType("image/*");
+        intent.setType(GALLERY_INTENT_TYPE);
         intent.setAction(Intent.ACTION_GET_CONTENT);
         startActivityForResult(intent, REQUEST_CODE_GALLERY);
     }

--- a/app/src/main/java/pl/temomuko/autostoprace/data/local/photo/PhotoShadowActivity.java
+++ b/app/src/main/java/pl/temomuko/autostoprace/data/local/photo/PhotoShadowActivity.java
@@ -229,7 +229,7 @@ public class PhotoShadowActivity extends BaseActivity {
 
     private void requestPhotoFromGallery() {
         Intent intent = new Intent();
-        intent.setType("image");
+        intent.setType("image/*");
         intent.setAction(Intent.ACTION_GET_CONTENT);
         startActivityForResult(intent, REQUEST_CODE_GALLERY);
     }


### PR DESCRIPTION
As mentioned by @szymenpl intent type "image" might cause crash on some devices and "image/*" should be used instead